### PR TITLE
Shrink webjar by excluding unnecessary content.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -81,7 +81,15 @@
                                 <unzip src="${project.build.directory}/${project.artifactId}.zip" dest="${destDir}">
                                     <patternset>
                                         <exclude name="${upstream.directory}/docs/**" />
+                                        <exclude name="${upstream.directory}/welcome/**" />
+                                        <exclude name="${upstream.directory}/src/**" />
+                                        <exclude name="${upstream.directory}/packages/**" />
+                                        <exclude name="${upstream.directory}/overrides/**" />
+                                        <exclude name="${upstream.directory}/licenses/**" />
+                                        <exclude name="${upstream.directory}/cmd/**" />
                                         <exclude name="${upstream.directory}/builds/**" />
+                                        <exclude name="${upstream.directory}/build/welcome/**" />
+                                        <exclude name="${upstream.directory}/build/examples/**" />
                                         <exclude name="${upstream.directory}/examples/**" />
                                         <exclude name="${upstream.directory}/**/*-classic-sandbox*" />
                                         <exclude name="${upstream.directory}/ext*rtl*.js" />


### PR DESCRIPTION
Hi guys,

I have excluded welcome/ src/ packages/ overrides/ licenses/ cmd/ build/welcome/ and build/examples/
and now the webjar is around ~15MB (compared to 85MB before). My project seems to work just fine, however I'm not 100% sure it won't break anyone else's project. 
